### PR TITLE
bugfix: closing new stream leads to panic

### DIFF
--- a/twitterstream.go
+++ b/twitterstream.go
@@ -252,7 +252,7 @@ func (c *Client) User(stream chan *Tweet, eventStream chan *Event, friendStream 
 // Close the client
 func (c *Client) Close() {
     //has it already been closed?
-    if c.conn.stale {
+    if c.conn == nil || c.conn.stale {
         return
     }
     c.conn.Close()


### PR DESCRIPTION
Before checking if the connection is stale a nil test is done.
